### PR TITLE
Telephony: Number of slot should start with 1

### DIFF
--- a/src/com/android/services/telephony/TelecomAccountRegistry.java
+++ b/src/com/android/services/telephony/TelecomAccountRegistry.java
@@ -157,7 +157,7 @@ final class TelecomAccountRegistry {
 
                 String slotIdString;
                 if (SubscriptionManager.isValidSlotId(slotId)) {
-                    slotIdString = Integer.toString(slotId);
+                    slotIdString = Integer.toString(slotId + 1);
                 } else {
                     slotIdString = mContext.getResources().getString(R.string.unknown);
                 }


### PR DESCRIPTION
* If an empty name is given to a sim card, the slots are numbered.
  The user will see slot 0 and slot 1 on dual sim ->
  Add 1 to make it 1, 2, ...

Change-Id: Idb56ff6b8d65718487bdeb05b62ad1f83c445db4