### PR TITLE
CallFeatureSettings: Only show call barring option if QTI package ins…

### DIFF
--- a/src/com/android/phone/CallFeaturesSetting.java
+++ b/src/com/android/phone/CallFeaturesSetting.java
@@ -359,6 +359,10 @@ public class CallFeaturesSetting extends PreferenceActivity
             prefSet.removePreference(findPreference("ims_settings_key"));
         }
 
+        if (!PackageManagerUtils.isAppInstalled(this, "com.qualcomm.qti.phonefeature")) {
+            prefSet.removePreference(findPreference("button_callbarring_expand_key"));
+        }
+
         Preference wifiCallingSettings = findPreference(
                 getResources().getString(R.string.wifi_calling_settings_key));
 


### PR DESCRIPTION
…talled

If this package is missing on a device (mostly because it's not supported),
trying to open the call barring settings will lead to a crash.

BUGBASH-191

Change-Id: I16e241f72d1cc3c53f847d48aed5c0c3a3850037